### PR TITLE
Limit `sync` to the root FS

### DIFF
--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -65,9 +65,6 @@ function warn_and_unfreeze() {
 # Make sure to unfreeze if we are done, but but also if there was an error or if we are interrupted
 trap warn_and_unfreeze SIGINT ERR
 
-# Sync data to disk
-sync
-
 {
   # Find the volumes for the instance
   instance=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
@@ -90,6 +87,8 @@ sync
   for target in $(findmnt -nlo TARGET -t ext4,xfs); {
     if [[ "$target" != "/"  ]]; then
       fsfreeze --freeze "$target";
+    else
+      sync -f "$target"
     fi
   }
 


### PR DESCRIPTION
Per https://serverfault.com/questions/609966/does-fsfreeze-flush-fs-caches, `fsfreeze` includes the `sync` call, and it happens *after* the FS has been frozen. So, we can remove the general `sync` call and only perform it for the root FS (better than nothing, if we cannot freeze it).