### PR TITLE
Avoid multiple `fsfreeze` calls on the same filesystem

### DIFF
--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -45,7 +45,7 @@ fi
 
 # Unfreeze file systems
 function unfreeze() {
-  for target in $(findmnt -nlo TARGET -t ext4,xfs); {
+  for target in $(findmnt -nlo UUID,TARGET -t ext4,xfs  | awk '!a[$1]++ { print $2 }'); {
     if [[ "$target" != "/"  ]]; then
       fsfreeze --unfreeze "$target";
     fi
@@ -87,7 +87,7 @@ sync
 
   # Find the mounted EXT4 and XFS partitions and freeze them
   # To avoid hanging the machine in unrecoverable way, don't freeze "/".
-  for target in $(findmnt -nlo TARGET -t ext4,xfs); {
+  for target in $(findmnt -nlo UUID,TARGET -t ext4,xfs  | awk '!a[$1]++ { print $2 }'); {
     if [[ "$target" != "/"  ]]; then
       fsfreeze --freeze "$target";
     fi


### PR DESCRIPTION
I have a "data" EBS volume and `mount -o bind ...` some directories like `/var/log/...` or `/var/www` to it. With that setup, 

```
$ findmnt -nlo TARGET -t ext4,xfs
/
/vol
/var/log/apache2
/var/log/mysql
/var/www
...
```

To avoid unnecessary and/or repeated `fsfreeze` calls, we can de-duplicate the filesystems based on their UUID.

```
$ findmnt -nlo UUID,TARGET -t ext4,xfs  | awk '!a[$1]++ { print $2 }'
/
/vol
```